### PR TITLE
copy over aws sam configs form streaming url branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 **/.vscode/settings.json
 demo-ui-config.js
 .idea/*
+**/.aws-sam/*
 
 # System Files
 **/.DS_Store

--- a/source/image-handler/README.md
+++ b/source/image-handler/README.md
@@ -1,0 +1,41 @@
+# Image Handler
+
+Takes a request input in the form:
+
+```json
+{
+  "bucket": "dronebase-production",
+  "key": "assets/mission/images/52697471-8332f7c4df712a509c77fc28a86a223837bd15a4/original-917d1f691173656dc6dd8b47d9a8b7b0286c22b5.jpg",
+  "edit": {}
+}
+```
+
+### Note: This is not deployed anywhere yet
+For images larges than 6mb, the Lambda function URL must be used. This will stream the response and allow for image up to a soft limit of 20mb in size. The streaming URL can be found in the AWS console under `Lambda > Functions > <Your Function Name>` then under "Function Overview" in the "Function URL" field. If the field is empty that means the Lambda function isn't configured to being invoked directly from a URL and must be accessed through AWS API gateway.
+```
+https://<id>.lambda-url.<region>.on.aws/resized_image/
+```
+
+## Build
+
+Build the SAM stack in a container. M1/M2 mac are not able to build the sharpJS library currently so building within a container is required.
+
+```bash
+sam build --use-container
+```
+
+
+## Deploy
+Deploy the SAM stack for the specified env. See `samconfig.toml` for env specific details.
+```bash
+sam deploy --config-env <dev | prod>
+```
+
+
+## Cleanup
+
+Delete the entire SAM stack.
+
+```bash
+sam delete
+```

--- a/source/image-handler/README.md
+++ b/source/image-handler/README.md
@@ -16,6 +16,11 @@ For images larges than 6mb, the Lambda function URL must be used. This will stre
 https://<id>.lambda-url.<region>.on.aws/resized_image/
 ```
 
+### SSO
+To run any of the commands below, you must have the correct AWS SSO profile set up. You can find more details in our confluence page here
+
+https://dronebase.atlassian.net/wiki/spaces/ENG/pages/394133505/Accessing+AWS+management+console+with+SSO#Configuring-SSO-for-Engineering-Developers
+
 ## Build
 
 Build the SAM stack in a container. M1/M2 mac are not able to build the sharpJS library currently so building within a container is required.
@@ -24,6 +29,12 @@ Build the SAM stack in a container. M1/M2 mac are not able to build the sharpJS 
 sam build --use-container
 ```
 
+## Local Testing
+
+This will start a local API Gateway and Lambda function to test the image handler.
+```bash
+sam local start-api
+```
 
 ## Deploy
 Deploy the SAM stack for the specified env. See `samconfig.toml` for env specific details.

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -8,14 +8,13 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "sharp": "^0.25.4",
+    "sharp": "^0.32.5",
     "sinon": "^7.3.2"
   },
   "devDependencies": {
-    "aws-sdk": "^2.437.0",
     "aws-sdk-mock": "^4.4.0",
-    "nyc": "^15.1.0",
-    "mocha": "^9.1.3"
+    "mocha": "^9.1.3",
+    "nyc": "^15.1.0"
   },
   "scripts": {
     "pretest": "npm install",
@@ -24,7 +23,10 @@
     "build:zip": "zip -rq image-handler.zip . -x template.yml",
     "build:dist": "mkdir dist && mv image-handler.zip dist/",
     "build": "npm run build:init && npm install --production && npm run build:zip && npm run build:dist",
-    "dev": "sam build --use-container; sam local start-api -p 8181"
+    "build:sam": "sam build --use-container",
+    "deploy:dev": "sam deploy --config-env dev",
+    "deploy:prod": "sam deploy --config-env prod",
+    "dev": "npm run build:sam; sam local start-api -p 8181"
   },
   "license": "Apache-2.0"
 }

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -8,6 +8,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@aws-sdk/client-rekognition": "^3.398.0",
+    "@aws-sdk/client-s3": "^3.400.0",
     "sharp": "^0.32.5",
     "sinon": "^7.3.2"
   },

--- a/source/image-handler/package.json
+++ b/source/image-handler/package.json
@@ -8,8 +8,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@aws-sdk/client-rekognition": "^3.398.0",
-    "@aws-sdk/client-s3": "^3.400.0",
+    "aws-sdk": "^2.1579.0",
     "sharp": "^0.32.5",
     "sinon": "^7.3.2"
   },

--- a/source/image-handler/samconfig.toml
+++ b/source/image-handler/samconfig.toml
@@ -1,0 +1,45 @@
+version = 0.1
+
+[default]
+stack_name = "image-handler-sam"
+
+[default.build.parameters]
+cached = true
+parallel = true
+
+[default.deploy.parameters]
+s3_prefix = "image-handler-sam"
+resolve_s3 = true
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+stack_name = "image-handler-sam"
+image_repositories = []
+
+[default.sync.parameters]
+watch = true
+
+[default.local_start_api.parameters]
+warm_containers = "EAGER"
+
+[dev]
+[dev.deploy.parameters]
+stack_name = "image-handler-dev"
+s3_prefix = "image-handler-dev"
+resolve_s3 = true
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+
+[prod]
+[prod.deploy.parameters]
+stack_name = "image-handler-prod"
+s3_prefix = "image-handler-prod"
+resolve_s3 = true
+region = "us-east-1"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+
+[production.sync]
+[production.sync.parameters]
+watch = false

--- a/source/image-handler/template.yml
+++ b/source/image-handler/template.yml
@@ -2,17 +2,23 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: An AWS Serverless Specification template describing your function.
 Resources:
-  imagehandlerdev:
+  ImageHandler:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs20.x
       CodeUri: .
-      Description: ''
+      Description: 'Image handler function'
       MemorySize: 512
-      Timeout: 60
-      Role: >-
-        arn:aws:iam::757639335249:role/service-role/image-handler-dev-role-n3isq2go
+      Timeout: 240
+      AutoPublishAlias: live
+      Policies:
+        - S3ReadPolicy:
+            BucketName: dronebase-development
+        - S3ReadPolicy:
+            BucketName: dronebase-staging
+        - S3ReadPolicy:
+            BucketName: dronebase-production
       Events:
         Api1:
           Type: Api
@@ -24,6 +30,20 @@ Resources:
           CACHE_CONTROL: max-age=7884000
           CORS_ENABLED: 'Yes'
           CORS_ORIGIN: '*'
+          SOURCE_BUCKET_REGION: 'us-east-1'
           SOURCE_BUCKETS: >-
             dronebase-production,dronebase-staging,dronebase-uploads-staging,dronebase-uploads-production,dronebase-development
-          TRUNCATE_PATH_PREFIX: resized_images/
+          TRUNCATE_PATH_PREFIX: "resized_images/"
+  ImageHandlerFuncUrl:
+    Type: AWS::Lambda::Url
+    Properties:
+      TargetFunctionArn: !Ref ImageHandler
+      AuthType: AWS_IAM
+      InvokeMode: RESPONSE_STREAM
+Outputs:
+  StreamingFunction:
+    Description: "Image Handler Lambda Function ARN"
+    Value: !GetAtt ImageHandler.Arn
+  StreamingFunctionURL:
+    Description: "Streaming Lambda Function URL"
+    Value: !GetAtt ImageHandlerFuncUrl.FunctionUrl

--- a/source/image-handler/template.yml
+++ b/source/image-handler/template.yml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       CodeUri: .
       Description: 'Image handler function'
       MemorySize: 512

--- a/source/image-handler/template.yml
+++ b/source/image-handler/template.yml
@@ -6,19 +6,22 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs18.x
       CodeUri: .
       Description: 'Image handler function'
       MemorySize: 512
       Timeout: 240
       AutoPublishAlias: live
-      Policies:
-        - S3ReadPolicy:
-            BucketName: dronebase-development
-        - S3ReadPolicy:
-            BucketName: dronebase-staging
-        - S3ReadPolicy:
-            BucketName: dronebase-production
+# Alternative to using a role
+#      Policies:
+#        - S3ReadPolicy:
+#            BucketName: dronebase-development
+#        - S3ReadPolicy:
+#            BucketName: dronebase-staging
+#        - S3ReadPolicy:
+#            BucketName: dronebase-production
+      Role: >-
+        arn:aws:iam::757639335249:role/service-role/image-handler-dev-role-n3isq2go
       Events:
         Api1:
           Type: Api
@@ -33,17 +36,4 @@ Resources:
           SOURCE_BUCKET_REGION: 'us-east-1'
           SOURCE_BUCKETS: >-
             dronebase-production,dronebase-staging,dronebase-uploads-staging,dronebase-uploads-production,dronebase-development
-          TRUNCATE_PATH_PREFIX: "resized_images/"
-  ImageHandlerFuncUrl:
-    Type: AWS::Lambda::Url
-    Properties:
-      TargetFunctionArn: !Ref ImageHandler
-      AuthType: AWS_IAM
-      InvokeMode: RESPONSE_STREAM
-Outputs:
-  StreamingFunction:
-    Description: "Image Handler Lambda Function ARN"
-    Value: !GetAtt ImageHandler.Arn
-  StreamingFunctionURL:
-    Description: "Streaming Lambda Function URL"
-    Value: !GetAtt ImageHandlerFuncUrl.FunctionUrl
+          TRUNCATE_PATH_PREFIX: resized_images/


### PR DESCRIPTION
- Add sam configs
  - The names of most of these are arbitrary and can be changed
- Update template.yml
  - while this is setup for streaming URLs (`ImageHandlerFuncUrl`), the actually node code can't handle them yet  
- Update packages 
  -  we're still using an outdated version of the aws-sdk that we'll need to update eventually